### PR TITLE
Safari Extension Framework Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Safari Extension Framework
 
-A framework for converting Chrome extensions to Safari extensions for macOS and iOS.
+A framework for converting Chrome extensions to Safari extensions for macOS and iOS. This framework makes it easy to build, test, and distribute Safari extensions.
 
 ## Features
 

--- a/example/safari-extension/extension/history.html
+++ b/example/safari-extension/extension/history.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Chronicle Sync History</title>
+    <link rel="stylesheet" href="history.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="history.js"></script>
+  </body>
+</html>

--- a/example/safari-extension/extension/popup.html
+++ b/example/safari-extension/extension/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>ChronicleSync Extension</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/example/safari-extension/extension/safari-extension-bridge.js
+++ b/example/safari-extension/extension/safari-extension-bridge.js
@@ -1,0 +1,185 @@
+// Safari Extension Bridge
+// This file provides compatibility between Chrome extension APIs and Safari extension APIs
+
+(function() {
+  // Create chrome namespace if it doesn't exist
+  if (typeof chrome === 'undefined') {
+    window.chrome = {};
+  }
+  
+  // Implement chrome.storage API
+  if (!chrome.storage) {
+    chrome.storage = {
+      local: {
+        get: function(keys, callback) {
+          // In Safari, we use localStorage for simple storage
+          const result = {};
+          
+          if (Array.isArray(keys)) {
+            keys.forEach(key => {
+              const value = localStorage.getItem(key);
+              if (value !== null) {
+                try {
+                  result[key] = JSON.parse(value);
+                } catch (e) {
+                  result[key] = value;
+                }
+              }
+            });
+          } else if (typeof keys === 'object') {
+            Object.keys(keys).forEach(key => {
+              const value = localStorage.getItem(key);
+              if (value !== null) {
+                try {
+                  result[key] = JSON.parse(value);
+                } catch (e) {
+                  result[key] = value;
+                }
+              } else {
+                result[key] = keys[key]; // Default value
+              }
+            });
+          } else if (typeof keys === 'string') {
+            const value = localStorage.getItem(keys);
+            if (value !== null) {
+              try {
+                result[keys] = JSON.parse(value);
+              } catch (e) {
+                result[keys] = value;
+              }
+            }
+          } else if (keys === null) {
+            // Get all items
+            for (let i = 0; i < localStorage.length; i++) {
+              const key = localStorage.key(i);
+              if (key) {
+                const value = localStorage.getItem(key);
+                if (value !== null) {
+                  try {
+                    result[key] = JSON.parse(value);
+                  } catch (e) {
+                    result[key] = value;
+                  }
+                }
+              }
+            }
+          }
+          
+          if (callback) {
+            callback(result);
+          }
+          
+          return Promise.resolve(result);
+        },
+        
+        set: function(items, callback) {
+          Object.keys(items).forEach(key => {
+            localStorage.setItem(key, JSON.stringify(items[key]));
+          });
+          
+          if (callback) {
+            callback();
+          }
+          
+          return Promise.resolve();
+        },
+        
+        remove: function(keys, callback) {
+          if (Array.isArray(keys)) {
+            keys.forEach(key => {
+              localStorage.removeItem(key);
+            });
+          } else if (typeof keys === 'string') {
+            localStorage.removeItem(keys);
+          }
+          
+          if (callback) {
+            callback();
+          }
+          
+          return Promise.resolve();
+        },
+        
+        clear: function(callback) {
+          localStorage.clear();
+          
+          if (callback) {
+            callback();
+          }
+          
+          return Promise.resolve();
+        }
+      },
+      
+      // Implement sync storage using local storage for now
+      sync: {
+        get: function(keys, callback) {
+          return chrome.storage.local.get(keys, callback);
+        },
+        
+        set: function(items, callback) {
+          return chrome.storage.local.set(items, callback);
+        },
+        
+        remove: function(keys, callback) {
+          return chrome.storage.local.remove(keys, callback);
+        },
+        
+        clear: function(callback) {
+          return chrome.storage.local.clear(callback);
+        }
+      }
+    };
+  }
+  
+  // Implement chrome.runtime API
+  if (!chrome.runtime) {
+    chrome.runtime = {
+      getURL: function(path) {
+        // In Safari, we can use browser.runtime.getURL
+        if (typeof browser !== 'undefined' && browser.runtime && browser.runtime.getURL) {
+          return browser.runtime.getURL(path);
+        }
+        
+        // Fallback: assume the path is relative to the current page
+        return path;
+      },
+      
+      sendMessage: function(message, callback) {
+        // In Safari, we can use browser.runtime.sendMessage
+        if (typeof browser !== 'undefined' && browser.runtime && browser.runtime.sendMessage) {
+          return browser.runtime.sendMessage(message).then(callback);
+        }
+        
+        // Fallback: use window.postMessage for simple messaging
+        window.postMessage({
+          type: 'safari-extension-message',
+          message: message
+        }, '*');
+        
+        if (callback) {
+          callback();
+        }
+        
+        return Promise.resolve();
+      }
+    };
+  }
+  
+  // Add listener for messages from native app (iOS/macOS)
+  window.addEventListener('message', function(event) {
+    if (event.data && event.data.type === 'safari-extension-message') {
+      // Handle message from native app
+      console.log('Received message from native app:', event.data.message);
+      
+      // Dispatch custom event for extension code to listen to
+      const customEvent = new CustomEvent('safari-extension-message', {
+        detail: event.data.message
+      });
+      
+      window.dispatchEvent(customEvent);
+    }
+  });
+  
+  console.log('Safari Extension Bridge loaded');
+})();

--- a/example/safari-extension/extension/settings.html
+++ b/example/safari-extension/extension/settings.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ChronicleSync Settings</title>
+    <link rel="stylesheet" type="text/css" href="settings.css">
+</head>
+<body>
+    <div class="settings-container">
+        <h1>ChronicleSync Settings</h1>
+        
+        <section class="settings-section">
+            <h2>Configuration</h2>
+            <div id="mnemonicContainer" class="setting-item">
+                <label for="mnemonic">Mnemonic Phrase:</label>
+                <textarea id="mnemonic" placeholder="Enter your 24-word mnemonic phrase" rows="3" required></textarea>
+                <div class="mnemonic-actions">
+                    <button id="generateMnemonic" class="secondary-button">Generate New</button>
+                    <button id="showMnemonic" class="secondary-button">Show/Hide</button>
+                </div>
+                <small class="help-text">Your mnemonic phrase is used to generate your unique client ID. Keep it safe!</small>
+            </div>
+            <div class="setting-item">
+                <label for="clientId">Client ID:</label>
+                <input type="text" id="clientId" placeholder="Generated from mnemonic" readonly>
+            </div>
+            <div class="setting-item">
+                <label for="environment">Environment:</label>
+                <select id="environment" required>
+                    <option value="production">Production</option>
+                    <option value="staging">Staging</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            <div id="customUrlContainer" class="setting-item" style="display: none;">
+                <label for="customApiUrl">Custom API URL:</label>
+                <input type="url" id="customApiUrl" placeholder="https://your-custom-api.com">
+                <small class="help-text">Only used when Environment is set to Custom</small>
+            </div>
+            <div class="setting-item">
+                <label for="expirationDays">History Expiration (Days):</label>
+                <input type="number" id="expirationDays" min="1" placeholder="7" required>
+                <small class="help-text">Number of days to keep history before expiring (minimum 1 day)</small>
+            </div>
+        </section>
+
+        <div class="settings-actions">
+            <button id="saveSettings" class="primary-button">Save Settings</button>
+            <button id="resetSettings" class="reset-settings">Reset to Default</button>
+        </div>
+    </div>
+    <script type="module" src="settings.js"></script>
+</body>
+</html>

--- a/example/safari-extension/extension/settings.html.modified
+++ b/example/safari-extension/extension/settings.html.modified
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ChronicleSync Settings</title>
+    <link rel="stylesheet" type="text/css" href="settings.css">
+    <!-- Safari Extension Bridge added by the framework -->
+    <script src="safari-extension-bridge.js"></script>
+</head>
+<body>
+    <div class="settings-container">
+        <h1>ChronicleSync Settings</h1>
+        
+        <section class="settings-section">
+            <h2>Configuration</h2>
+            <div id="mnemonicContainer" class="setting-item">
+                <label for="mnemonic">Mnemonic Phrase:</label>
+                <textarea id="mnemonic" placeholder="Enter your 24-word mnemonic phrase" rows="3" required></textarea>
+                <div class="mnemonic-actions">
+                    <button id="generateMnemonic" class="secondary-button">Generate New</button>
+                    <button id="showMnemonic" class="secondary-button">Show/Hide</button>
+                </div>
+                <small class="help-text">Your mnemonic phrase is used to generate your unique client ID. Keep it safe!</small>
+            </div>
+            <div class="setting-item">
+                <label for="clientId">Client ID:</label>
+                <input type="text" id="clientId" placeholder="Generated from mnemonic" readonly>
+            </div>
+            <div class="setting-item">
+                <label for="environment">Environment:</label>
+                <select id="environment" required>
+                    <option value="production">Production</option>
+                    <option value="staging">Staging</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            <div id="customUrlContainer" class="setting-item" style="display: none;">
+                <label for="customApiUrl">Custom API URL:</label>
+                <input type="url" id="customApiUrl" placeholder="https://your-custom-api.com">
+                <small class="help-text">Only used when Environment is set to Custom</small>
+            </div>
+            <div class="setting-item">
+                <label for="expirationDays">History Expiration (Days):</label>
+                <input type="number" id="expirationDays" min="1" placeholder="7" required>
+                <small class="help-text">Number of days to keep history before expiring (minimum 1 day)</small>
+            </div>
+        </section>
+
+        <div class="settings-actions">
+            <button id="saveSettings" class="primary-button">Save Settings</button>
+            <button id="resetSettings" class="reset-settings">Reset to Default</button>
+        </div>
+    </div>
+    <script type="module" src="settings.js"></script>
+</body>
+</html>

--- a/example/safari-extension/extension/settings.js
+++ b/example/safari-extension/extension/settings.js
@@ -1,0 +1,89 @@
+// This is a simplified example of what the settings.js file might look like
+document.addEventListener('DOMContentLoaded', function() {
+  // Get references to UI elements
+  const mnemonicInput = document.getElementById('mnemonic');
+  const clientIdInput = document.getElementById('clientId');
+  const environmentSelect = document.getElementById('environment');
+  const customUrlContainer = document.getElementById('customUrlContainer');
+  const customApiUrlInput = document.getElementById('customApiUrl');
+  const expirationDaysInput = document.getElementById('expirationDays');
+  const saveButton = document.getElementById('saveSettings');
+  const resetButton = document.getElementById('resetSettings');
+  const generateMnemonicButton = document.getElementById('generateMnemonic');
+  const showMnemonicButton = document.getElementById('showMnemonic');
+  
+  // Load saved settings
+  loadSettings();
+  
+  // Add event listeners
+  environmentSelect.addEventListener('change', function() {
+    customUrlContainer.style.display = this.value === 'custom' ? 'block' : 'none';
+  });
+  
+  saveButton.addEventListener('click', saveSettings);
+  resetButton.addEventListener('click', resetSettings);
+  generateMnemonicButton.addEventListener('click', generateMnemonic);
+  showMnemonicButton.addEventListener('click', toggleMnemonicVisibility);
+  
+  // Function to load settings
+  function loadSettings() {
+    // In a real implementation, this would load settings from storage
+    chrome.storage.local.get(['mnemonic', 'clientId', 'environment', 'customApiUrl', 'expirationDays'], function(result) {
+      if (result.mnemonic) mnemonicInput.value = result.mnemonic;
+      if (result.clientId) clientIdInput.value = result.clientId;
+      if (result.environment) environmentSelect.value = result.environment;
+      if (result.customApiUrl) customApiUrlInput.value = result.customApiUrl;
+      if (result.expirationDays) expirationDaysInput.value = result.expirationDays;
+      
+      // Update UI based on environment
+      customUrlContainer.style.display = environmentSelect.value === 'custom' ? 'block' : 'none';
+    });
+  }
+  
+  // Function to save settings
+  function saveSettings() {
+    const settings = {
+      mnemonic: mnemonicInput.value,
+      clientId: clientIdInput.value,
+      environment: environmentSelect.value,
+      customApiUrl: customApiUrlInput.value,
+      expirationDays: parseInt(expirationDaysInput.value) || 7
+    };
+    
+    // In a real implementation, this would save settings to storage
+    chrome.storage.local.set(settings, function() {
+      alert('Settings saved successfully!');
+      
+      // Notify Safari app that settings were saved (for iOS)
+      if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.settingsSaved) {
+        window.webkit.messageHandlers.settingsSaved.postMessage({
+          success: true
+        });
+      }
+    });
+  }
+  
+  // Function to reset settings
+  function resetSettings() {
+    mnemonicInput.value = '';
+    clientIdInput.value = '';
+    environmentSelect.value = 'production';
+    customApiUrlInput.value = '';
+    expirationDaysInput.value = '7';
+    customUrlContainer.style.display = 'none';
+  }
+  
+  // Function to generate a mnemonic
+  function generateMnemonic() {
+    // In a real implementation, this would generate a secure mnemonic
+    mnemonicInput.value = 'example mnemonic phrase for demonstration purposes only';
+    
+    // Generate client ID from mnemonic
+    clientIdInput.value = 'generated-client-id-123456';
+  }
+  
+  // Function to toggle mnemonic visibility
+  function toggleMnemonicVisibility() {
+    mnemonicInput.type = mnemonicInput.type === 'password' ? 'text' : 'password';
+  }
+});

--- a/example/safari-extension/ios-app/App/SettingsViewController.swift
+++ b/example/safari-extension/ios-app/App/SettingsViewController.swift
@@ -1,0 +1,96 @@
+import UIKit
+import SafariServices
+import WebKit
+
+class SettingsViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
+    private var webView: WKWebView!
+    private var activityIndicator: UIActivityIndicatorView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupWebView()
+        setupActivityIndicator()
+        loadSettingsPage()
+    }
+    
+    private func setupWebView() {
+        let configuration = WKWebViewConfiguration()
+        let userContentController = WKUserContentController()
+        
+        // Add script message handlers for communication between JS and Swift
+        userContentController.add(self, name: "settingsSaved")
+        userContentController.add(self, name: "settingsError")
+        
+        configuration.userContentController = userContentController
+        
+        webView = WKWebView(frame: view.bounds, configuration: configuration)
+        webView.navigationDelegate = self
+        webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(webView)
+    }
+    
+    private func setupActivityIndicator() {
+        activityIndicator = UIActivityIndicatorView(style: .large)
+        activityIndicator.center = view.center
+        activityIndicator.hidesWhenStopped = true
+        view.addSubview(activityIndicator)
+    }
+    
+    private func loadSettingsPage() {
+        activityIndicator.startAnimating()
+        
+        // Get the URL to the settings.html file in the extension bundle
+        if let extensionBundle = Bundle(identifier: "com.example.chroniclesync.Extension"),
+           let settingsURL = extensionBundle.url(forResource: "settings", withExtension: "html") {
+            webView.loadFileURL(settingsURL, allowingReadAccessTo: settingsURL.deletingLastPathComponent())
+        } else {
+            showError("Could not load settings page")
+        }
+    }
+    
+    // MARK: - WKNavigationDelegate
+    
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        activityIndicator.stopAnimating()
+    }
+    
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        activityIndicator.stopAnimating()
+        showError("Failed to load settings: \(error.localizedDescription)")
+    }
+    
+    // MARK: - WKScriptMessageHandler
+    
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        switch message.name {
+        case "settingsSaved":
+            if let messageBody = message.body as? [String: Any],
+               let success = messageBody["success"] as? Bool {
+                if success {
+                    showAlert(title: "Success", message: "Settings saved successfully")
+                } else {
+                    showError(messageBody["error"] as? String ?? "Unknown error")
+                }
+            }
+        case "settingsError":
+            if let messageBody = message.body as? [String: Any],
+               let errorMessage = messageBody["error"] as? String {
+                showError(errorMessage)
+            }
+        default:
+            break
+        }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func showError(_ message: String) {
+        showAlert(title: "Error", message: message)
+    }
+    
+    private func showAlert(title: String, message: String) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alertController, animated: true)
+    }
+}


### PR DESCRIPTION
This PR implements a framework for converting Chrome extensions to Safari extensions for macOS and iOS.

## Features

- Chrome to Safari extension conversion
- iOS and macOS app generation
- Build scripts for testing and distribution
- GitHub Actions workflows for CI/CD
- Comprehensive documentation

The framework is designed to work with JavaScript (potentially generated from TypeScript) and implements a standard Chrome extension conversion to Safari extension with proper iOS testing support.

## Example

An example Safari extension has been added to demonstrate how the framework works with source HTML and JS files. The example includes:

- Original HTML files from the ChronicleSync extension
- A sample settings.js file
- A Safari extension compatibility bridge
- An iOS SettingsViewController that loads the settings HTML

## GitHub Actions

GitHub Actions workflows have been moved to the root directory and configured to work with the example directory by default. They include parameters to specify which directory to build and release.